### PR TITLE
Add SocketRequestType tests

### DIFF
--- a/Tests/SocketRequestTypeTests.swift
+++ b/Tests/SocketRequestTypeTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import upbit
+
+// Extend SocketRequestType for Codable conformance in tests
+extension SocketRequestType: Codable {}
+
+final class SocketRequestTypeTests: XCTestCase {
+    func testJSONEncodingDecoding() throws {
+        let cases: [SocketRequestType] = [.ticker, .orderbook, .myOrder, .trade]
+        let encoder = JSONEncoder()
+        let decoder = JSONDecoder()
+
+        for value in cases {
+            let data = try encoder.encode(value)
+            let decoded = try decoder.decode(SocketRequestType.self, from: data)
+            XCTAssertEqual(decoded, value)
+        }
+    }
+
+    func testAuthenticationRequirement() {
+        XCTAssertTrue(SocketRequestType.myOrder.requiresAuth)
+        XCTAssertFalse(SocketRequestType.ticker.requiresAuth)
+    }
+}


### PR DESCRIPTION
## Summary
- create `SocketRequestTypeTests` verifying Codable behavior
- check authentication requirement logic

## Testing
- `swiftc --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c4aa88f8832b933ebd8ab07437e7