### PR TITLE
Add real-time order updates

### DIFF
--- a/upbit/Coordinator/DetailPageCoordinator.swift
+++ b/upbit/Coordinator/DetailPageCoordinator.swift
@@ -27,7 +27,8 @@ class DetailPageCoordinator: Coordinator {
         let orderViewController = OrderViewController(viewModel:
                                                         OrderViewModel(market: self.marketInfo.market,
                                                                        tickerObservable:  viewModel.tickerSubject.asObservable(),
-                                                                       orderbookObservable: viewModel.orderbookSubject.asObservable()))
+                                                                       orderbookObservable: viewModel.orderbookSubject.asObservable(),
+                                                                       myOrderObservable: viewModel.myOrderSubject.asObservable()))
         
         // MARK: 차트 페이지
         let chartViewController = ChartViewController(viewModel: ChartViewModel())

--- a/upbit/ViewController/OrderViewController.swift
+++ b/upbit/ViewController/OrderViewController.swift
@@ -7,6 +7,8 @@
 
 import UIKit
 import RxSwift
+import RxCocoa
+import SnapKit
 import Toast
 
 class OrderViewController: UIViewController {
@@ -19,12 +21,15 @@ class OrderViewController: UIViewController {
     
     // MARK: 호가정보
     private var orderbookUnits: [obUnits] = [obUnits]()
-    
+
     // MARK: 현재가
     private var ticker:SocketTicker?
-    
+
     // MARK: 주문 가능 정보
     private var chance:Chance?
+
+    // MARK: 실시간 주문 정보
+    private var myOrders: [MyOrder] = []
     
     // MARK: 호가창 가운데 정렬 여부
     private var isAlignCenter:Bool = false
@@ -95,7 +100,16 @@ class OrderViewController: UIViewController {
         
         return label
     }()
-    
+
+    // MARK: 실시간 주문 표시 라벨
+    private lazy var myOrderLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = ThemeColor.label1
+        label.numberOfLines = 0
+        return label
+    }()
+
     // MARK: 기준가 텍스트
     private lazy var priceTextFeild: BorderedTextField = {
         let textField = BorderedTextField()
@@ -196,7 +210,7 @@ class OrderViewController: UIViewController {
         [self.tableView, orderBackgroundView].forEach(self.view.addSubview(_:))
         orderBackgroundView.addSubview(orderView)
         [self.segmentedControl, orderStackView, self.orderButton].forEach(orderView.addSubview(_:))
-        [self.priceLabel, self.priceTextFeild, UIView(), self.amountLabel, self.amountTextFeild, self.orderSlider, self.orderInfoView, self.accountInfoView, self.minOrderInfoView].forEach(orderStackView.addArrangedSubview(_:))
+        [self.priceLabel, self.priceTextFeild, UIView(), self.amountLabel, self.amountTextFeild, self.orderSlider, self.orderInfoView, self.accountInfoView, self.minOrderInfoView, self.myOrderLabel].forEach(orderStackView.addArrangedSubview(_:))
         
         tableView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -276,6 +290,15 @@ class OrderViewController: UIViewController {
             .subscribe(onNext: { [weak self] message in
                 guard let self = self else { return }
                 self.view.makeToast(message, duration: 2.0, position: .bottom)
+            }).disposed(by: disposeBag)
+
+        // MARK: 실시간 주문 구독
+        self.viewModel.myOrderSubject
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] order in
+                guard let self = self else { return }
+                self.myOrders.insert(order, at: 0)
+                self.updateMyOrderLabel()
             }).disposed(by: disposeBag)
         
         
@@ -562,6 +585,17 @@ class OrderViewController: UIViewController {
             let availableAsset = chance.askAccount.balanceDecimal
             return (availableAsset * percentage).truncatedTo8Digits()
         }
+    }
+
+    // MARK: 실시간 주문 라벨 업데이트
+    private func updateMyOrderLabel() {
+        let texts = myOrders.prefix(5).map { order in
+            let side = order.ask_bid == "bid" ? "매수" : "매도"
+            let price = Decimal(order.price).formattedStringWithTruncation(places: 0)
+            let volume = Decimal(order.volume).formattedStringWithTruncation(places: 8)
+            return "\(side) \(volume) @ \(price)"
+        }
+        self.myOrderLabel.text = texts.joined(separator: "\n")
     }
     
     // MARK: 호가창 테이블뷰의 스크롤을 가운데로 정렬

--- a/upbit/ViewModel/OrderViewModel.swift
+++ b/upbit/ViewModel/OrderViewModel.swift
@@ -8,32 +8,48 @@
 import RxSwift
 
 class OrderViewModel {
-    
+
     // MARK: disposeBag
     private let disposeBag = DisposeBag()
-    
+
     // MARK: 현재가 Observable
     private(set) var tickerObservable: Observable<SocketTicker>
-    
+
     // MARK: 호가 Observable
     private(set) var orderbookObservable: Observable<Orderbook>
-    
+
+    // MARK: 실시간 주문 Observable
+    private(set) var myOrderObservable: Observable<MyOrder>
+
     // MARK: - Place for Input
     // MARK: 선택된 마켓
     private let market: String
-    
+
     // MARK: - Place for Output
     // MARK: 주문가능정보 주제
     let chanceSubject: PublishSubject<Chance> = PublishSubject<Chance>()
-    
+
     // MARK: 메세지 주제
     let messageSubject: PublishSubject<String> = PublishSubject<String>()
-    
-    init(market: String, tickerObservable: Observable<SocketTicker>, orderbookObservable: Observable<Orderbook>) {
+
+    // MARK: 실시간 주문 주제
+    let myOrderSubject: PublishSubject<MyOrder> = PublishSubject<MyOrder>()
+
+    init(market: String,
+         tickerObservable: Observable<SocketTicker>,
+         orderbookObservable: Observable<Orderbook>,
+         myOrderObservable: Observable<MyOrder>) {
         self.market = market
         self.tickerObservable = tickerObservable
         self.orderbookObservable = orderbookObservable
-        
+        self.myOrderObservable = myOrderObservable
+
+        self.myOrderObservable
+            .subscribe(onNext: { [weak self] order in
+                self?.myOrderSubject.onNext(order)
+            })
+            .disposed(by: disposeBag)
+
         self.fetchChance(market: market)
     }
     


### PR DESCRIPTION
## Summary
- pass my order stream from detail coordinator to order view
- handle my order observable in view model and forward via subject
- display recent my orders in order screen

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c6e88bee8832b9b4e329e5d750a13