### PR TITLE
Add order history view

### DIFF
--- a/upbit.xcodeproj/project.pbxproj
+++ b/upbit.xcodeproj/project.pbxproj
@@ -70,7 +70,8 @@
 		F16DE5982DA7F4E800E357D2 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DE5972DA7F4E800E357D2 /* ChatViewModel.swift */; };
 		F16DE59A2DA7F4EA00E357D2 /* OrderBookViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DE5992DA7F4EA00E357D2 /* OrderBookViewModel.swift */; };
 		F16DE59C2DA7F4EE00E357D2 /* ChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DE59B2DA7F4EE00E357D2 /* ChartViewModel.swift */; };
-		F16DE5A02DA7F88A00E357D2 /* OrderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DE59F2DA7F88A00E357D2 /* OrderCell.swift */; };
+                F16DE5A02DA7F88A00E357D2 /* OrderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DE59F2DA7F88A00E357D2 /* OrderCell.swift */; };
+                0E346E94722E4C0B831C3AAB /* HistoryCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F5AF2C68A04EBFA6AC77E3 /* HistoryCell.swift */; };
 		F16DE5A22DA7FBF800E357D2 /* OrderBook.swift in Sources */ = {isa = PBXBuildFile; fileRef = F16DE5A12DA7FBF800E357D2 /* OrderBook.swift */; };
 		F19484DD2D9C0CF20040E675 /* AccountCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19484DC2D9C0CF20040E675 /* AccountCoordinator.swift */; };
 		F19484DF2D9C0FC40040E675 /* DetailPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F19484DE2D9C0FC40040E675 /* DetailPageViewController.swift */; };
@@ -95,10 +96,11 @@
 		F10629E22D71DEC600EC48B6 /* SocketRequestType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketRequestType.swift; sourceTree = "<group>"; };
 		F10629E42D71E09E00EC48B6 /* SocketTicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketTicker.swift; sourceTree = "<group>"; };
 		F10B157D2D9A79F300FF6D5C /* AccountCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCell.swift; sourceTree = "<group>"; };
-		F10B15812D9AA92300FF6D5C /* AccountTableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTableDataSource.swift; sourceTree = "<group>"; };
-		F1160EE02D6D8C1E006A19EC /* UpbitApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpbitApiService.swift; sourceTree = "<group>"; };
-		F1160EE22D6D9313006A19EC /* MarketInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketInfo.swift; sourceTree = "<group>"; };
-		F1160EE72D6D9BEF006A19EC /* MarketTableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketTableDataSource.swift; sourceTree = "<group>"; };
+                F10B15812D9AA92300FF6D5C /* AccountTableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountTableDataSource.swift; sourceTree = "<group>"; };
+                F1160EE02D6D8C1E006A19EC /* UpbitApiService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpbitApiService.swift; sourceTree = "<group>"; };
+                F1160EE22D6D9313006A19EC /* MarketInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketInfo.swift; sourceTree = "<group>"; };
+                20F5AF2C68A04EBFA6AC77E3 /* HistoryCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HistoryCell.swift; sourceTree = "<group>"; };
+                F1160EE72D6D9BEF006A19EC /* MarketTableDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarketTableDataSource.swift; sourceTree = "<group>"; };
 		F1160EE92D6DA65D006A19EC /* AbType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AbType.swift; sourceTree = "<group>"; };
 		F1160EEB2D6DA66C006A19EC /* ApiTicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiTicker.swift; sourceTree = "<group>"; };
 		F1160EED2D6DA6F0006A19EC /* CurrencyType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyType.swift; sourceTree = "<group>"; };
@@ -342,13 +344,14 @@
 		F129F0252D63147000F3A74C /* Cell */ = {
 			isa = PBXGroup;
 			children = (
-				F129F0492D6361C800F3A74C /* MarketCell.swift */,
-				F10B157D2D9A79F300FF6D5C /* AccountCell.swift */,
-				F16DE59F2DA7F88A00E357D2 /* OrderCell.swift */,
-			);
-			path = Cell;
-			sourceTree = "<group>";
-		};
+                F129F0492D6361C800F3A74C /* MarketCell.swift */, 
+                F10B157D2D9A79F300FF6D5C /* AccountCell.swift */, 
+                F16DE59F2DA7F88A00E357D2 /* OrderCell.swift */, 
+                20F5AF2C68A04EBFA6AC77E3 /* HistoryCell.swift */, 
+            );
+            path = Cell;
+            sourceTree = "<group>";
+        };
 		F129F0262D63147500F3A74C /* CustomView */ = {
 			isa = PBXGroup;
 			children = (
@@ -526,8 +529,9 @@
 				F16DE5A22DA7FBF800E357D2 /* OrderBook.swift in Sources */,
 				F129EFFB2D6310F100F3A74C /* AppDelegate.swift in Sources */,
 				F129F0382D631C0100F3A74C /* MainTabBarCoordinator.swift in Sources */,
-				F16DE5A02DA7F88A00E357D2 /* OrderCell.swift in Sources */,
-				F10B15822D9AA92300FF6D5C /* AccountTableDataSource.swift in Sources */,
+                                F16DE5A02DA7F88A00E357D2 /* OrderCell.swift in Sources */, 
+                                0E346E94722E4C0B831C3AAB /* HistoryCell.swift in Sources */, 
+                                F10B15822D9AA92300FF6D5C /* AccountTableDataSource.swift in Sources */, 
 				F16DE59A2DA7F4EA00E357D2 /* OrderBookViewModel.swift in Sources */,
 				F10B157E2D9A79F300FF6D5C /* AccountCell.swift in Sources */,
 				F15FE9D32D9825E100D89A2A /* AccountTicker.swift in Sources */,

--- a/upbit/Cell/HistoryCell.swift
+++ b/upbit/Cell/HistoryCell.swift
@@ -1,0 +1,76 @@
+//
+//  HistoryCell.swift
+//  upbit
+//
+//  Created by OpenAI on 2024.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+class HistoryCell: UITableViewCell {
+    static let cellId = "HistoryCell"
+
+    let coinLabel = UILabel()
+    let priceLabel = UILabel()
+    let executedLabel = UILabel()
+    let remainingLabel = UILabel()
+    let cancelButton = UIButton(type: .system)
+
+    var disposeBag = DisposeBag()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        layout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        disposeBag = DisposeBag()
+    }
+
+    private func layout() {
+        [coinLabel, priceLabel, executedLabel, remainingLabel, cancelButton].forEach(contentView.addSubview)
+
+        coinLabel.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().inset(8)
+        }
+
+        priceLabel.snp.makeConstraints { make in
+            make.top.equalTo(coinLabel.snp.bottom).offset(4)
+            make.leading.equalTo(coinLabel)
+        }
+
+        executedLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(coinLabel)
+            make.trailing.equalToSuperview().inset(8)
+        }
+
+        remainingLabel.snp.makeConstraints { make in
+            make.centerY.equalTo(priceLabel)
+            make.trailing.equalTo(executedLabel)
+        }
+
+        cancelButton.setTitle("취소", for: .normal)
+        cancelButton.snp.makeConstraints { make in
+            make.top.equalTo(remainingLabel.snp.bottom).offset(8)
+            make.trailing.equalToSuperview().inset(8)
+            make.bottom.equalToSuperview().inset(8)
+        }
+    }
+
+    func configure(order: MyOrder, showCancel: Bool) {
+        coinLabel.text = order.code
+        priceLabel.text = Decimal(order.price).formattedStringWithTruncation(places: 0)
+        executedLabel.text = "체결: \(Decimal(order.executed_volume).formattedStringWithTruncation(places: 8))"
+        remainingLabel.text = "미체결: \(Decimal(order.remaining_volume).formattedStringWithTruncation(places: 8))"
+        cancelButton.isHidden = !showCancel
+    }
+}
+

--- a/upbit/Coordinator/DetailPageCoordinator.swift
+++ b/upbit/Coordinator/DetailPageCoordinator.swift
@@ -37,7 +37,7 @@ class DetailPageCoordinator: Coordinator {
         let orderBookViewController = OrderBookViewController(viewModel: OrderBookViewModel())
         
         // MARK: 거래내역 페이지
-        let historyViewController = HistoryViewController(viewModel: HistoryViewModel())
+        let historyViewController = HistoryViewController(viewModel: HistoryViewModel(myOrderObservable: viewModel.myOrderSubject.asObservable()))
         
         // MARK: 종목토론방 페이지
         let chatViewController = ChatViewController(viewModel: ChatViewModel())

--- a/upbit/Model/MyOrder.swift
+++ b/upbit/Model/MyOrder.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 주문 및 체결 내역(*WebSocket 용)
-struct MyOrder: Decodable {
+struct MyOrder: Decodable, Hashable {
     /// 타입 (myOrder : 내 주문)
     let type: String
     

--- a/upbit/Service/UpbitApiService.swift
+++ b/upbit/Service/UpbitApiService.swift
@@ -89,9 +89,12 @@ extension UpbitApiService {
         
         // MARK: 주문 가능 정보
         case ordersChance(market: String)
-        
+
         // MARK: 주문
         case orders(market: String, side: String, volume: String, price: String, ordType: String)
+
+        // MARK: 주문 취소
+        case cancelOrder(uuid: String)
         
         // MARK: 요청 경로
         var path: String {
@@ -110,9 +113,12 @@ extension UpbitApiService {
                 
             case .ordersChance:
                 return "orders/chance"
-                
+
             case .orders:
                 return "orders"
+
+            case .cancelOrder:
+                return "order"
             }
         }
         
@@ -137,6 +143,9 @@ extension UpbitApiService {
                 
             case .orders(let market, let side, let volume, let price, let ordType):
                 return ["market" : market, "side" : side, "volume" : volume, "price" : price, "ord_type" : ordType]
+
+            case .cancelOrder(let uuid):
+                return ["uuid" : uuid]
             }
         }
         
@@ -148,7 +157,7 @@ extension UpbitApiService {
                 return nil
                 
                 // MARK: 인증이 필요한 요청
-            case .accounts, .ordersChance, .orders:
+            case .accounts, .ordersChance, .orders, .cancelOrder:
                 let jwt = self.generateJWT()
                 return ["Authorization": "Bearer \(jwt)"]
             }

--- a/upbit/ViewController/HistoryViewController.swift
+++ b/upbit/ViewController/HistoryViewController.swift
@@ -6,27 +6,92 @@
 //
 
 import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
 
 class HistoryViewController: UIViewController {
-    
+
     // MARK: ViewModel
     private let viewModel: HistoryViewModel
-    
+    private let disposeBag = DisposeBag()
+
+    private enum Section { case main }
+
+    private lazy var segmentedControl: UISegmentedControl = {
+        let control = UISegmentedControl(items: ["체결", "미체결"])
+        control.selectedSegmentIndex = 0
+        return control
+    }()
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.register(HistoryCell.self, forCellReuseIdentifier: HistoryCell.cellId)
+        tableView.separatorStyle = .none
+        tableView.rowHeight = UITableView.automaticDimension
+        return tableView
+    }()
+
+    private lazy var dataSource = UITableViewDiffableDataSource<Section, MyOrder>(tableView: tableView) { [weak self] tableView, indexPath, order in
+        let cell = tableView.dequeueReusableCell(withIdentifier: HistoryCell.cellId, for: indexPath) as! HistoryCell
+        let showCancel = self?.segmentedControl.selectedSegmentIndex == 1
+        cell.configure(order: order, showCancel: showCancel ?? false)
+        if let self = self {
+            cell.cancelButton.rx.tap
+                .map { order.uuid }
+                .bind(to: self.viewModel.cancelSubject)
+                .disposed(by: cell.disposeBag)
+        }
+        return cell
+    }
+
     init(viewModel: HistoryViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.layout()
+        layout()
+        bind()
     }
-    
+
     private func layout() {
-        
+        view.addSubview(segmentedControl)
+        view.addSubview(tableView)
+
+        segmentedControl.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide.snp.top).offset(8)
+            make.leading.trailing.equalToSuperview().inset(16)
+        }
+
+        tableView.snp.makeConstraints { make in
+            make.top.equalTo(segmentedControl.snp.bottom).offset(8)
+            make.leading.trailing.bottom.equalToSuperview()
+        }
+    }
+
+    private func bind() {
+        let orders = segmentedControl.rx.selectedSegmentIndex
+            .startWith(0)
+            .flatMapLatest { [weak self] index -> Observable<[MyOrder]> in
+                guard let self = self else { return .empty() }
+                return index == 0 ? self.viewModel.filledOrdersRelay.asObservable() : self.viewModel.pendingOrdersRelay.asObservable()
+            }
+
+        orders
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] items in
+                var snapshot = NSDiffableDataSourceSnapshot<Section, MyOrder>()
+                snapshot.appendSections([.main])
+                snapshot.appendItems(items)
+                self?.dataSource.apply(snapshot, animatingDifferences: true)
+            })
+            .disposed(by: disposeBag)
     }
 }
+

--- a/upbit/ViewController/OrderViewController.swift
+++ b/upbit/ViewController/OrderViewController.swift
@@ -28,8 +28,6 @@ class OrderViewController: UIViewController {
     // MARK: 주문 가능 정보
     private var chance:Chance?
 
-    // MARK: 실시간 주문 정보
-    private var myOrders: [MyOrder] = []
     
     // MARK: 호가창 가운데 정렬 여부
     private var isAlignCenter:Bool = false
@@ -101,14 +99,6 @@ class OrderViewController: UIViewController {
         return label
     }()
 
-    // MARK: 실시간 주문 표시 라벨
-    private lazy var myOrderLabel: UILabel = {
-        let label = UILabel()
-        label.font = .systemFont(ofSize: 12)
-        label.textColor = ThemeColor.label1
-        label.numberOfLines = 0
-        return label
-    }()
 
     // MARK: 기준가 텍스트
     private lazy var priceTextFeild: BorderedTextField = {
@@ -210,7 +200,7 @@ class OrderViewController: UIViewController {
         [self.tableView, orderBackgroundView].forEach(self.view.addSubview(_:))
         orderBackgroundView.addSubview(orderView)
         [self.segmentedControl, orderStackView, self.orderButton].forEach(orderView.addSubview(_:))
-        [self.priceLabel, self.priceTextFeild, UIView(), self.amountLabel, self.amountTextFeild, self.orderSlider, self.orderInfoView, self.accountInfoView, self.minOrderInfoView, self.myOrderLabel].forEach(orderStackView.addArrangedSubview(_:))
+        [self.priceLabel, self.priceTextFeild, UIView(), self.amountLabel, self.amountTextFeild, self.orderSlider, self.orderInfoView, self.accountInfoView, self.minOrderInfoView].forEach(orderStackView.addArrangedSubview(_:))
         
         tableView.snp.makeConstraints { make in
             make.top.equalTo(view.safeAreaLayoutGuide.snp.top)
@@ -292,16 +282,6 @@ class OrderViewController: UIViewController {
                 self.view.makeToast(message, duration: 2.0, position: .bottom)
             }).disposed(by: disposeBag)
 
-        // MARK: 실시간 주문 구독
-        self.viewModel.myOrderSubject
-            .observe(on: MainScheduler.instance)
-            .subscribe(onNext: { [weak self] order in
-                guard let self = self else { return }
-                self.myOrders.insert(order, at: 0)
-                self.updateMyOrderLabel()
-            }).disposed(by: disposeBag)
-        
-        
         // MARK: segementedControl Index + chanceSubejct 결합
         Observable
             .combineLatest(
@@ -587,17 +567,6 @@ class OrderViewController: UIViewController {
         }
     }
 
-    // MARK: 실시간 주문 라벨 업데이트
-    private func updateMyOrderLabel() {
-        let texts = myOrders.prefix(5).map { order in
-            let side = order.ask_bid == "bid" ? "매수" : "매도"
-            let price = Decimal(order.price).formattedStringWithTruncation(places: 0)
-            let volume = Decimal(order.volume).formattedStringWithTruncation(places: 8)
-            return "\(side) \(volume) @ \(price)"
-        }
-        self.myOrderLabel.text = texts.joined(separator: "\n")
-    }
-    
     // MARK: 호가창 테이블뷰의 스크롤을 가운데로 정렬
     private func centerTableView() {
         if orderbookUnits.count == 0 { return }

--- a/upbit/ViewModel/HistoryViewModel.swift
+++ b/upbit/ViewModel/HistoryViewModel.swift
@@ -6,7 +6,59 @@
 //
 
 import Foundation
+import RxSwift
+import RxCocoa
 
 class HistoryViewModel {
-    
+
+    // MARK: 주문 목록
+    private var pendingOrders: [String: MyOrder] = [:]
+    private var filledOrders: [MyOrder] = []
+
+    // MARK: Output
+    let pendingOrdersRelay = BehaviorRelay<[MyOrder]>(value: [])
+    let filledOrdersRelay = BehaviorRelay<[MyOrder]>(value: [])
+
+    // MARK: Input
+    let cancelSubject = PublishSubject<String>()
+
+    private let disposeBag = DisposeBag()
+
+    init(myOrderObservable: Observable<MyOrder>) {
+        myOrderObservable
+            .observe(on: MainScheduler.instance)
+            .subscribe(onNext: { [weak self] order in
+                self?.handle(order)
+            })
+            .disposed(by: disposeBag)
+
+        cancelSubject
+            .flatMapLatest { uuid -> Observable<Void> in
+                return Observable.create { observer in
+                    UpbitApiService.request(endpoint: .cancelOrder(uuid: uuid), method: .delete) { (result: Result<Order, Error>) in
+                        observer.onNext(())
+                        observer.onCompleted()
+                    }
+                    return Disposables.create()
+                }
+            }
+            .subscribe()
+            .disposed(by: disposeBag)
+    }
+
+    private func handle(_ order: MyOrder) {
+        switch order.state {
+        case "done":
+            pendingOrders.removeValue(forKey: order.uuid)
+            filledOrders.insert(order, at: 0)
+        case "cancel":
+            pendingOrders.removeValue(forKey: order.uuid)
+        default:
+            pendingOrders[order.uuid] = order
+        }
+
+        pendingOrdersRelay.accept(Array(pendingOrders.values))
+        filledOrdersRelay.accept(filledOrders)
+    }
 }
+


### PR DESCRIPTION
## Summary
- move realtime order updates to new history page
- allow canceling pending orders and track fills
- support order cancellation endpoint

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689c728f1ba4832bb9246da8c2b48516